### PR TITLE
Fix background image path in SCSS

### DIFF
--- a/chat-app-firebase/src/styles/Home.module.scss
+++ b/chat-app-firebase/src/styles/Home.module.scss
@@ -1,7 +1,8 @@
 .home_container {
   $padding: 20px;
   padding: $padding;
-  background: url(/src/assets/background-image-double.jpg) center no-repeat;
+  /* Use relative path so webpack can resolve the image correctly */
+  background: url(../assets/background-image-double.jpg) center no-repeat;
   background-size: cover;
   background-attachment: fixed;
 }


### PR DESCRIPTION
## Summary
- fix wrong asset path in Home.module.scss causing build failure

## Testing
- `npm test --silent` *(fails: no tests specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b599a244c83219b8d75e04de684f0